### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/template/cfn/index.js
+++ b/template/cfn/index.js
@@ -70,7 +70,7 @@ function lambda(name){
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["CFNLambdaRole","Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     }


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #1 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
